### PR TITLE
speed up compute PMI value 80x and degree calculation 200x

### DIFF
--- a/src/PRUNE.py
+++ b/src/PRUNE.py
@@ -172,15 +172,8 @@ def compute_PMI(graph, nodeCount, in_degrees, out_degrees, alpha=5.0):
     alpha: reprensents the number of effective negative samples
            for each positive sample
     """
-    PMI_values = np.zeros((len(graph), 1))
-    for ind in range(len(graph)):
-        head, tail = graph[ind]
-        pmi = len(graph) / alpha / out_degrees[head] / in_degrees[tail]
-        PMI_values[ind, 0] = np.log(pmi)
-
-    PMI_values[PMI_values < 0] = 0
-
-    return PMI_values
+    PMI_values = np.clip(np.log(len(graph) / alpha / out_degrees[graph[:, 0]] / in_degrees[graph[:, 1]]), 0, None)
+    return np.reshape(PMI_values, (len(PMI_values), 1))
 
 
 def run_PRUNE(lamb, graph, nodeCount, n_emb, learning_rate, epoch,
@@ -191,11 +184,8 @@ def run_PRUNE(lamb, graph, nodeCount, n_emb, learning_rate, epoch,
     Initialize and train PRUNE for node embeddings
     """
     # compute indegrees, outdegrees, PMI values
-    out_degrees = np.zeros(nodeCount)
-    in_degrees = np.zeros(nodeCount)
-    for node_i, node_j in graph:
-        out_degrees[node_i] += 1
-        in_degrees[node_j] += 1
+    out_degrees = np.bincount(graph[:, 0], minlength=nodeCount)
+    in_degrees = np.bincount(graph[:, 1], minlength=nodeCount)
 
     PMI_values = compute_PMI(graph, nodeCount, in_degrees, out_degrees)
 


### PR DESCRIPTION
test by following code:

```
import logging
import numpy as np
import timeit
 
 
def load_origin(graph, nodeCount):
    out_degrees = np.zeros(nodeCount)
    in_degrees = np.zeros(nodeCount)
    for node_i, node_j in graph:
        out_degrees[node_i] += 1
        in_degrees[node_j] += 1
    return out_degrees, in_degrees
 
 
def load_new(graph, nodeCount):
    out_degrees = np.bincount(graph[:, 0], minlength=nodeCount)
    in_degrees = np.bincount(graph[:, 1], minlength=nodeCount)
    return out_degrees, in_degrees
 
 
def compute_PMI_origin(graph, nodeCount, in_degrees, out_degrees, alpha=5.0):
    PMI_values = np.zeros((len(graph), 1))
    for ind in range(len(graph)):
        head, tail = graph[ind]
        pmi = len(graph) / alpha / out_degrees[head] / in_degrees[tail]
        PMI_values[ind, 0] = np.log(pmi)
 
    PMI_values[PMI_values < 0] = 0
 
    return PMI_values
 
 
def compute_PMI_new(graph, nodeCount, in_degrees, out_degrees, alpha=5.0):
    PMI_values = np.clip(np.log(len(graph) / alpha / out_degrees[graph[:, 0]] / in_degrees[graph[:, 1]]), 0, None)
    return np.reshape(PMI_values, (len(PMI_values), 1))
 
 
def main():
    graph = np.loadtxt('sample/graph.edgelist').astype(np.int32)
    nodeCount = graph.max() + 1
 
    n = 1000
    timer_start = timeit.default_timer()
    for _ in range(n):
        result_origin = load_origin(graph, nodeCount)
    timer_end = timeit.default_timer()
    time_origin = timer_end - timer_start
    logging.info('Origin: %f sec', time_origin)
 
    timer_start = timeit.default_timer()
    for _ in range(n):
        result_new = load_new(graph, nodeCount)
    timer_end = timeit.default_timer()
    time_new = timer_end - timer_start
    logging.info('New: %f sec', time_new)
    np.testing.assert_array_equal(result_origin, result_new)
    logging.info('Speed up: %fx', time_origin / time_new)
 
    in_degrees, out_degrees = result_origin
    timer_start = timeit.default_timer()
    for _ in range(n):
        result_origin = compute_PMI_origin(graph, nodeCount, in_degrees, out_degrees)
    timer_end = timeit.default_timer()
    time_origin = timer_end - timer_start
    logging.info('Origin: %f sec', time_origin)
 
    timer_start = timeit.default_timer()
    for _ in range(n):
        result_new = compute_PMI_new(graph, nodeCount, in_degrees, out_degrees)
    timer_end = timeit.default_timer()
    time_new = timer_end - timer_start
    logging.info('New: %f sec', time_new)
    np.testing.assert_array_equal(result_origin, result_new)
    logging.info('Speed up: %fx', time_origin / time_new)
 
 
if __name__ == '__main__':
    logging.basicConfig(format='[%(asctime)s] %(message)s', level=logging.INFO)
    main()
```